### PR TITLE
Removes automatic indexing from mongodb pipeline

### DIFF
--- a/pipeline/history.mongodb.conf
+++ b/pipeline/history.mongodb.conf
@@ -23,10 +23,15 @@ filter {
   # select only timestamp from metadata
   ruby {
     code => '
-      event.get("[contextResponses][contextElement][attributes][metadatas]").each do |i|
-        if i["name"] == "TimeInstant"
-          event.set("[ts]", i["value"])
-          break
+      data = event.get("[contextResponses][contextElement][attributes][metadatas]")
+      if data == nil
+        event.cancel
+      else
+        data.each do |i|
+          if i["name"] == "TimeInstant"
+            event.set("[ts]", i["value"])
+            break
+          end
         end
       end
     '
@@ -48,20 +53,6 @@ filter {
       "[host]", "[originator]",
       "[subscriptionId]"
     ]
-  }
-
-  # this is truly awful: index the output collection
-  ruby {
-    code => '
-      require "mongo"
-
-      conn = Mongo::Client.new("mongodb://mongodb")
-      db = conn.use("device_history")
-      svc = event.get("[service]")
-      dev = event.get("[device_id]")
-      view = db[svc+"_"+dev].indexes
-      view.create_one({ts: -1, attr: 1}, {unique: true, drop_dups: true})
-    '
   }
 }
 


### PR DESCRIPTION
Due to an old version of the mongo gem (2.0.6) being used by the
mongodb-output plugin for logstash, it is impossible to forcibly
sever all connections to the database within the filter, thus
resulting in all filter executions spawning a new, permanent but
stale thread, thus wasting the logger machine's resources.